### PR TITLE
Fix catching exceptions in compensation actions

### DIFF
--- a/lib/sage/executor.ex
+++ b/lib/sage/executor.ex
@@ -265,8 +265,9 @@ defmodule Sage.Executor do
 
   defp safe_apply_compensation_fun(compensation, effect_to_compensate, name_and_reason, opts) do
     apply_compensation_fun(compensation, effect_to_compensate, name_and_reason, opts)
+  rescue
+    exception -> {:raise, {exception, System.stacktrace()}}
   catch
-    :error, exception -> {:raise, {exception, System.stacktrace()}}
     :exit, reason -> {:exit, reason}
     :throw, error -> {:throw, error}
   else


### PR DESCRIPTION
Elixir encourages developers to use `try .. rescue` to catch
exceptions instead of `try ... catch :error, exception`, because
the latter form doesn't convert Erlang errors to Elixir exceptions.

For example, if compensation action contains a bug and calls
non-existent module or function, then this error will be swallowed
by function `return_or_reraise`, which will raise something like
`:undef.exception/1 is undefined` and original exception will be lost.