### PR TITLE
Fix catching exceptions in transaction functions

### DIFF
--- a/lib/sage/executor.ex
+++ b/lib/sage/executor.ex
@@ -135,8 +135,9 @@ defmodule Sage.Executor do
 
   defp execute_transaction({:run, transaction, _compensation, []}, effects_so_far, opts) do
     apply_transaction_fun(transaction, effects_so_far, opts)
+  rescue
+    exception -> {:raise, {exception, System.stacktrace()}}
   catch
-    :error, exception -> {:raise, {exception, System.stacktrace()}}
     :exit, reason -> {:exit, reason}
     :throw, reason -> {:throw, reason}
   end


### PR DESCRIPTION
Similar to what has been done in e8de6c8. Some errors
aren't converted to Elixir exceptions when caught by
`try .. catch :error, exception .. end` construction.
For example, `FunctionClauseError` would be swallowed
by `return_or_reraise` and original exception will be
lost.