### PR TITLE
improve malformed transaction error messages

### DIFF
--- a/lib/sage/exceptions.ex
+++ b/lib/sage/exceptions.ex
@@ -96,12 +96,12 @@ defmodule Sage.MalformedTransactionReturnError do
   @moduledoc """
   Raised at runtime when the transaction or operation has an malformed return.
   """
-  defexception [:name, :transaction, :return]
+  defexception [:stage, :transaction, :return]
 
   @impl true
-  def message(%__MODULE__{name: name, transaction: transaction, return: return}) do
+  def message(%__MODULE__{stage: stage, transaction: transaction, return: return}) do
     """
-    expected transaction #{inspect(transaction)} for stage #{inspect(name)} to return
+    expected transaction #{inspect(transaction)} for stage #{inspect(stage)} to return
     {:ok, effect}, {:error, reason} or {:abort, reason}, got:
 
       #{inspect(return)}
@@ -113,12 +113,12 @@ defmodule Sage.MalformedCompensationReturnError do
   @moduledoc """
   Raised at runtime when the compensation or operation has an malformed return.
   """
-  defexception [:name, :compensation, :return]
+  defexception [:stage, :compensation, :return]
 
   @impl true
-  def message(%__MODULE__{name: name, compensation: compensation, return: return}) do
+  def message(%__MODULE__{stage: stage, compensation: compensation, return: return}) do
     """
-    expected compensation #{inspect(compensation)} for stage #{inspect(name)} to return
+    expected compensation #{inspect(compensation)} for stage #{inspect(stage)} to return
     :ok, :abort, {:retry, retry_opts} or {:continue, effect}, got:
 
       #{inspect(return)}

--- a/lib/sage/exceptions.ex
+++ b/lib/sage/exceptions.ex
@@ -96,12 +96,12 @@ defmodule Sage.MalformedTransactionReturnError do
   @moduledoc """
   Raised at runtime when the transaction or operation has an malformed return.
   """
-  defexception [:transaction, :return]
+  defexception [:name, :transaction, :return]
 
   @impl true
-  def message(%__MODULE__{transaction: transaction, return: return}) do
+  def message(%__MODULE__{name: name, transaction: transaction, return: return}) do
     """
-    expected transaction #{inspect(transaction)} to return
+    expected transaction #{inspect(transaction)} for stage #{inspect(name)} to return
     {:ok, effect}, {:error, reason} or {:abort, reason}, got:
 
       #{inspect(return)}
@@ -113,12 +113,12 @@ defmodule Sage.MalformedCompensationReturnError do
   @moduledoc """
   Raised at runtime when the compensation or operation has an malformed return.
   """
-  defexception [:compensation, :return]
+  defexception [:name, :compensation, :return]
 
   @impl true
-  def message(%__MODULE__{compensation: compensation, return: return}) do
+  def message(%__MODULE__{name: name, compensation: compensation, return: return}) do
     """
-    expected compensation #{inspect(compensation)} to return
+    expected compensation #{inspect(compensation)} for stage #{inspect(name)} to return
     :ok, :abort, {:retry, retry_opts} or {:continue, effect}, got:
 
       #{inspect(return)}

--- a/lib/sage/executor.ex
+++ b/lib/sage/executor.ex
@@ -124,7 +124,7 @@ defmodule Sage.Executor do
   defp maybe_execute_transaction({{name, operation}, state}, opts) do
     {_last_effect_or_error, effects_so_far, _retries, _abort?, _tasks, _on_compensation_error, tracers} = state
     tracers = maybe_notify_tracers(tracers, :start_transaction, name)
-    return = execute_transaction(operation, effects_so_far, opts)
+    return = execute_transaction(operation, name, effects_so_far, opts)
 
     tracers =
       case return do
@@ -136,8 +136,8 @@ defmodule Sage.Executor do
     {name, operation, return, state}
   end
 
-  defp execute_transaction({:run, transaction, _compensation, []}, effects_so_far, opts) do
-    apply_transaction_fun(transaction, effects_so_far, opts)
+  defp execute_transaction({:run, transaction, _compensation, []}, name, effects_so_far, opts) do
+    apply_transaction_fun(name, transaction, effects_so_far, opts)
   rescue
     exception -> {:raise, {exception, System.stacktrace()}}
   catch
@@ -145,19 +145,19 @@ defmodule Sage.Executor do
     :throw, reason -> {:throw, reason}
   end
 
-  defp execute_transaction({:run_async, transaction, _compensation, tx_opts}, effects_so_far, opts) do
+  defp execute_transaction({:run_async, transaction, _compensation, tx_opts}, name, effects_so_far, opts) do
     logger_metadata = Logger.metadata()
 
     task =
       Task.Supervisor.async_nolink(Sage.AsyncTransactionSupervisor, fn ->
         Logger.metadata(logger_metadata)
-        apply_transaction_fun(transaction, effects_so_far, opts)
+        apply_transaction_fun(name, transaction, effects_so_far, opts)
       end)
 
     {task, tx_opts}
   end
 
-  defp apply_transaction_fun({mod, fun, args} = mfa, effects_so_far, opts) do
+  defp apply_transaction_fun(name, {mod, fun, args} = mfa, effects_so_far, opts) do
     apply(mod, fun, [effects_so_far, opts | args])
   else
     {:ok, effect} ->
@@ -170,10 +170,11 @@ defmodule Sage.Executor do
       {:abort, reason}
 
     other ->
-      {:raise, {%Sage.MalformedTransactionReturnError{transaction: mfa, return: other}, System.stacktrace()}}
+      {:raise,
+       {%Sage.MalformedTransactionReturnError{name: name, transaction: mfa, return: other}, System.stacktrace()}}
   end
 
-  defp apply_transaction_fun(fun, effects_so_far, opts) do
+  defp apply_transaction_fun(name, fun, effects_so_far, opts) do
     apply(fun, [effects_so_far, opts])
   else
     {:ok, effect} ->
@@ -186,7 +187,8 @@ defmodule Sage.Executor do
       {:abort, reason}
 
     other ->
-      {:raise, {%Sage.MalformedTransactionReturnError{transaction: fun, return: other}, System.stacktrace()}}
+      {:raise,
+       {%Sage.MalformedTransactionReturnError{name: name, transaction: fun, return: other}, System.stacktrace()}}
   end
 
   defp handle_transaction_result({:start_compensations, state}), do: {:start_compensations, state}
@@ -264,13 +266,13 @@ defmodule Sage.Executor do
     {name_and_reason, effects_so_far, retries, abort?, [], on_compensation_error, tracers} = state
     {effect_to_compensate, effects_so_far} = Map.pop(effects_so_far, name)
     tracers = maybe_notify_tracers(tracers, :start_compensation, name)
-    return = safe_apply_compensation_fun(compensation, effect_to_compensate, effects_so_far, opts)
+    return = safe_apply_compensation_fun(name, compensation, effect_to_compensate, effects_so_far, opts)
     tracers = maybe_notify_tracers(tracers, :finish_compensation, name)
     state = {name_and_reason, effects_so_far, retries, abort?, [], on_compensation_error, tracers}
     {name, operation, return, effect_to_compensate, state}
   end
 
-  defp safe_apply_compensation_fun(compensation, effect_to_compensate, effects_so_far, opts) do
+  defp safe_apply_compensation_fun(name, compensation, effect_to_compensate, effects_so_far, opts) do
     apply_compensation_fun(compensation, effect_to_compensate, effects_so_far, opts)
   rescue
     exception -> {:raise, {exception, System.stacktrace()}}
@@ -291,7 +293,7 @@ defmodule Sage.Executor do
       {:continue, effect}
 
     other ->
-      exception_struct = %Sage.MalformedCompensationReturnError{compensation: compensation, return: other}
+      exception_struct = %Sage.MalformedCompensationReturnError{name: name, compensation: compensation, return: other}
       {:raise, {exception_struct, System.stacktrace()}}
   end
 

--- a/lib/sage/executor.ex
+++ b/lib/sage/executor.ex
@@ -171,7 +171,7 @@ defmodule Sage.Executor do
 
     other ->
       {:raise,
-       {%Sage.MalformedTransactionReturnError{name: name, transaction: mfa, return: other}, System.stacktrace()}}
+       {%Sage.MalformedTransactionReturnError{stage: name, transaction: mfa, return: other}, System.stacktrace()}}
   end
 
   defp apply_transaction_fun(name, fun, effects_so_far, opts) do
@@ -188,7 +188,7 @@ defmodule Sage.Executor do
 
     other ->
       {:raise,
-       {%Sage.MalformedTransactionReturnError{name: name, transaction: fun, return: other}, System.stacktrace()}}
+       {%Sage.MalformedTransactionReturnError{stage: name, transaction: fun, return: other}, System.stacktrace()}}
   end
 
   defp handle_transaction_result({:start_compensations, state}), do: {:start_compensations, state}
@@ -293,7 +293,7 @@ defmodule Sage.Executor do
       {:continue, effect}
 
     other ->
-      exception_struct = %Sage.MalformedCompensationReturnError{name: name, compensation: compensation, return: other}
+      exception_struct = %Sage.MalformedCompensationReturnError{stage: name, compensation: compensation, return: other}
       {:raise, {exception_struct, System.stacktrace()}}
   end
 


### PR DESCRIPTION
This PR adds the stage name to `Sage.MalformedTransactionReturnError` and `Sage.MalformedCompensationReturnError` instances to improve usefuless when debugging.

### BEFORE:
```elixir
** (Sage.MalformedTransactionReturnError) expected transaction
#Function<0.11651793/2 in :erl_eval.expr/5> to return
{:ok, effect}, {:error, reason} or {:abort, reason}, got:

  :bad
```

### AFTER:
```elixir
** (Sage.MalformedTransactionReturnError) expected transaction
#Function<13.91303403/2 in :erl_eval.expr/5> for stage :foo to return
{:ok, effect}, {:error, reason} or {:abort, reason}, got:

  :bad
```