### PR TITLE
Ensure retrying doesn't clear effect state

### DIFF
--- a/lib/sage/executor.ex
+++ b/lib/sage/executor.ex
@@ -370,7 +370,7 @@ defmodule Sage.Executor do
     state(attempts: attempts) = state
 
     if Retries.retry_with_backoff?(attempts, retry_opts) do
-      state = state(attempts: attempts + 1)
+      state = state(state, attempts: attempts + 1)
       {:retry_transaction, {name, operation}, state}
     else
       {:next_compensation, {name, operation}, state}


### PR DESCRIPTION
There is currently a bug in 0.6.0 where if you have a saga like

```elixir

Sage.new()
|> Sage.run(:step1, transaction)
|> Sage.run(:step2, transaction, compensation_with_retry(3))
|> Sage.run(...)
|> Sage.execute(...)
```

Where step2 has a `retry` compensation, then the executor overrides the current execution state with only an incremented attempt number. This wipes out previous effects so you are unable to reuse step1's result on the retry of step2.

I have added a test to prove this bug - it fails without the fix, and passes with it.

Also fixes https://github.com/Nebo15/sage/issues/52