### PR TITLE
Allow docs to lead to github source

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,7 @@ defmodule Sage.Mixfile do
   defp docs do
     [
       main: "readme",
-      source_ref: "v#\{@version\}",
+      source_ref: @version,
       source_url: "https://github.com/Nebo15/sage",
       extras: ["README.md"]
     ]


### PR DESCRIPTION
Using the bare `@version` number since that is what is used as tag names on the github repo.