### PR TITLE
Allows users to pass in their own Supervisor for async steps

### DIFF
--- a/lib/sage.ex
+++ b/lib/sage.ex
@@ -70,8 +70,15 @@ defmodule Sage do
 
   @typedoc """
   Options for asynchronous transaction stages.
+
+  Available async options:
+
+  * `:timeout` - the maximum amount of time we will await the task used for an async step (in ms).\
+  If :infinity is used it will wait forever.
+  * `:supervisor` - The name of a supervisor that the task will be spawned under. Defaults to the\
+  `Sage.AsyncTransactionSupervisor` started by Sage.
   """
-  @type async_opts :: [{:timeout, integer() | :infinity}]
+  @type async_opts :: [{:timeout, integer() | :infinity} | {:supervisor, atom()}]
 
   @typedoc """
   Retry options.
@@ -382,6 +389,10 @@ defmodule Sage do
 
     * `:timeout` - the time in milliseconds to wait for the transaction to finish, \
     `:infinity` will wait indefinitely (default: 5000);
+    * `:supervisor` - the name of a supervisor that the task will be spawned under. Defaults to the\
+    `Sage.AsyncTransactionSupervisor` started by Sage (meaning it will exist under Sage's supervision\
+    tree). It might be a good idea to pass your own in to avoid race conditions on shutdown if your\
+    step interacts with a process in your own app's supervision tree.
   """
   @spec run_async(
           sage :: t(),

--- a/lib/sage.ex
+++ b/lib/sage.ex
@@ -71,12 +71,10 @@ defmodule Sage do
   @typedoc """
   Options for asynchronous transaction stages.
 
-  Available async options:
+  ## Options
 
-  * `:timeout` - the maximum amount of time we will await the task used for an async step (in ms).\
-  If :infinity is used it will wait forever.
-  * `:supervisor` - The name of a supervisor that the task will be spawned under. Defaults to the\
-  `Sage.AsyncTransactionSupervisor` started by Sage.
+  * `:timeout` - a timeout in milliseconds or `:infinity` for which we will await for the task process to finish the execution, default: `5000`. For more details see Elixir's `Task.await/2`;
+  * `:supervisor` - the name of a `Task.Supervisor` process that will be used to spawn the async task. Defaults to the `Sage.AsyncTransactionSupervisor` started by Sage application.
   """
   @type async_opts :: [{:timeout, integer() | :infinity} | {:supervisor, atom()}]
 

--- a/lib/sage.ex
+++ b/lib/sage.ex
@@ -300,7 +300,7 @@ defmodule Sage do
 
   Tracer can be a module that must implement `Sage.Tracer` behaviour,
   a function, or a tuple in a shape of `{module, function, [extra_arguments]}`. 
-  
+
   In any case, the function called should follow the definition of `c:Sage.Tracer.handle_event/3`
   and accept at least 3 required arguments that are documented by the callback.
 
@@ -427,8 +427,8 @@ defmodule Sage do
   ## Async Stages
 
   If you are using `run_async/5` with `transaction/4` the code that is run in async stages would
-  not reuse the same database connection, which menas that if transaction is rolled back the effects
-  of async stages should still be rolled back manually.
+  not reuse the same database connection, which means that if the transaction is rolled back the
+  effects of async stages should still be rolled back manually.
   """
   @doc since: "0.3.3"
   @spec transaction(sage :: t(), repo :: module(), opts :: any(), transaction_opts :: any()) ::

--- a/lib/sage/executor.ex
+++ b/lib/sage/executor.ex
@@ -182,9 +182,10 @@ defmodule Sage.Executor do
 
   defp execute_transaction({:run_async, transaction, _compensation, tx_opts}, name, effects_so_far, attrs) do
     logger_metadata = Logger.metadata()
+    supervisor = Keyword.get(tx_opts, :supervisor, Sage.AsyncTransactionSupervisor)
 
     task =
-      Task.Supervisor.async_nolink(Sage.AsyncTransactionSupervisor, fn ->
+      Task.Supervisor.async_nolink(supervisor, fn ->
         _ = Logger.metadata(logger_metadata)
         apply_transaction_fun(name, transaction, effects_so_far, attrs)
       end)

--- a/test/sage/executor_test.exs
+++ b/test/sage/executor_test.exs
@@ -98,9 +98,7 @@ defmodule Sage.ExecutorTest do
     |> run_async(:step1, step, :noop, supervisor: supervisor)
     |> execute(1)
 
-    # The async task will be awaited as it's the last step in the pipeline meaning
-    # there's no chance that we reach here _before_ the send has happened (causing a flaky test)
-    assert_received({^ref, ancestors}, 1_000)
+    assert_receive({^ref, ancestors})
     assert [Sage.MyTestSupervisor | _rest] = ancestors
   end
 
@@ -118,9 +116,7 @@ defmodule Sage.ExecutorTest do
     |> run_async(:step1, step, :noop)
     |> execute(1)
 
-    # The async task will be awaited as it's the last step in the pipeline meaning
-    # there's no chance that we reach here _before_ the send has happened (causing a flaky test)
-    assert_received({^ref, ancestors}, 1_000)
+    assert_receive({^ref, ancestors})
     assert [Sage.AsyncTransactionSupervisor | _rest] = ancestors
   end
 


### PR DESCRIPTION
Imagine an app called Blog that uses Sage.

Currently Sage allows async steps that spin up a task supervised under `Sage.AsyncTransactionSupervisor`. Because Sage is a dep of Blog, on shutdown Blog will shutdown _before_ Sage does.

That means if an async step interacts with a process under Blog's supervision tree and you are using some sort of rolling deploy you can enter the following scenario:

1. Blog starts async task
2. Sage starts doing that task
3. Blog shuts down
4. Sage tries to interact with a process in Blog and can't - so it crashes / errors.

Possible Solutions

1. Make Sage a library and allow users to start it themselves?
2. Allow the user to pass in their own supervisor under which it can start the async steps.

This PR does 2.