### PR TITLE
Fix AsyncTransactionTimeoutError timeout unit in error message

### DIFF
--- a/lib/sage/exceptions.ex
+++ b/lib/sage/exceptions.ex
@@ -21,7 +21,7 @@ defmodule Sage.AsyncTransactionTimeoutError do
   def message(%__MODULE__{name: name, timeout: timeout}) do
     """
     asynchronous transaction for operation #{name} has timed out,
-    expected it to return within #{to_string(timeout)} microseconds
+    expected it to return within #{to_string(timeout)} milliseconds
     """
   end
 end


### PR DESCRIPTION
The `AsyncTransactionTimeoutError` error message says 5000 microseconds when the actual timeout is 5000 milliseconds