### PR TITLE
feat: added interleave/4

### DIFF
--- a/lib/sage.ex
+++ b/lib/sage.ex
@@ -448,8 +448,9 @@ defmodule Sage do
     do: add_stage(sage, name, build_operation!(:run_async, transaction, compensation, opts))
 
   @doc """
-  For a given Sage S with transactions :t1 -> :t2 -> :t3, a call to `interleave(S, :name, f)`
-  will yield a saga with transactions :t1 -> :name_1 -> :t2 -> :name_2 -> :t3 -> :name_3.
+  For a given Sage S with transactions `:t1` -> `:t2` -> `:t3`, a call to `interleave(S, :name, f)`
+  will yield a saga with transactions `:t1` -> `{:interleave, :name, 1}` -> `:t2` -> `{:interleave, :name, 2}`
+  -> `:t3` -> `{:interleave, :name, 3}`.
 
   This can be useful if you are trying to do a long computation and want to do something with
   the intermediate results, such as logging or persistence.

--- a/lib/sage.ex
+++ b/lib/sage.ex
@@ -474,7 +474,7 @@ defmodule Sage do
       |> Enum.reverse()
       |> Enum.with_index(1)
       |> Enum.flat_map(fn {stage, index} ->
-        name = String.to_atom("#{name}_#{index}")
+        name = {:interleave, name, index}
         {stage_name, _} = stage
 
         transaction =

--- a/test/sage_test.exs
+++ b/test/sage_test.exs
@@ -269,10 +269,9 @@ defmodule SageTest do
     end
 
     test "adds nothing if there are no transactions" do
-      assert [] =
-               new()
-               |> interleave(:i, fn _effects, _args, _previous_stage_name -> :ok end)
-               |> Map.get(:stages)
+      sage = interleave(new(), :i, fn _effects, _args, _previous_stage_name -> :ok end)
+
+      assert sage.stages == []
     end
 
     test "adds a transaction at the end if there is one transaction" do

--- a/test/support/test_intermediate_transaction_handler.ex
+++ b/test/support/test_intermediate_transaction_handler.ex
@@ -1,0 +1,5 @@
+defmodule TestIntermediateTransactionHandler do
+  def intermediate_transaction_handler(_effects, _args, previous_stage_name, something_else) do
+    {:ok, {previous_stage_name, something_else}}
+  end
+end


### PR DESCRIPTION
## What is being changed
Adding: `Sage.interleave/4`. This allows the user to add a transaction to be executed after every stage they had manually defined before.

## Rationale
Say you're working with a "token" struct, and you want to saga-fy this kind of code where you want to do something 
with the intermediate results
```elixir
t = new_big_struct()
with {:ok, %BigStruct{} = t} <- op1(t),
  log(t),
  {:ok, %BigStruct{} = t} <- op2(t),
  log(t)
 #... more steps
```
This code is a bit tedious to write to begin with and this PR is meant to enable Sage to help with this kind of pattern by turning the above code into 
```elixir
t = new_big_struct()
Sage.new()
|> Sage.run(:op1, fn _, _ -> op1(t) end)
|> Sage.run(:op2, fn _, _ -> op2(t) end)
... more steps
|> Sage.interleave(:log, fn effects, _attrs, last_effect_name -> {:ok, log(effects[last_effect_name])} end)
```